### PR TITLE
Add beta calculations, Localize alpha and beta to Factory, Add a gaging limit

### DIFF
--- a/contracts/interfaces/IEternalFactory.sol
+++ b/contracts/interfaces/IEternalFactory.sol
@@ -9,10 +9,8 @@ pragma solidity 0.8.0;
 interface IEternalFactory {
     // Initiates a liquid gage involving an ETRNL liquidity pair
     function initiateEternalLiquidGage(address asset, uint256 amount) external payable returns(uint256);
-    // Sets the address of the Eternal Treasury contract
-    function setEternalTreasury(address newContract) external;
-    // Sets the address of the Eternal Token contract
-    function setEternalToken(address newContract) external;
+    // Updates the 24h counters for the treasury and token
+    function updateCounters(uint256 amount) external;
     
     // Signals the deployment of a new gage
     event NewGage(uint256 id, address indexed gageAddress);

--- a/contracts/interfaces/IEternalStorage.sol
+++ b/contracts/interfaces/IEternalStorage.sol
@@ -9,36 +9,42 @@ pragma solidity 0.8.0;
 interface IEternalStorage {
     // Scalar setters
     function setUint(bytes32 entity, bytes32 key, uint256 value) external;
+    function setInt(bytes32 entity, bytes32 key, int256 value) external;
     function setAddress(bytes32 entity, bytes32 key, address value) external;
     function setBool(bytes32 entity, bytes32 key, bool value) external;
     function setBytes(bytes32 entity, bytes32 key, bytes32 value) external;
 
     // Scalar getters
     function getUint(bytes32 entity, bytes32 key) external view returns(uint256);
+    function getInt(bytes32 entity, bytes32 key) external view returns(int256);
     function getAddress(bytes32 entity, bytes32 key) external view returns(address);
     function getBool(bytes32 entity, bytes32 key) external view returns(bool);
     function getBytes(bytes32 entity, bytes32 key) external view returns(bytes32);
 
     // Array setters
     function setUintArrayValue(bytes32 key, uint256 index, uint256 value) external;
+    function setIntArrayValue(bytes32 key, uint256 index, int256 value) external;
     function setAddressArrayValue(bytes32 key, uint256 index, address value) external;
     function setBoolArrayValue(bytes32 key, uint256 index, bool value) external;
     function setBytesArrayValue(bytes32 key, uint256 index, bytes32 value) external;
 
     // Array getters
     function getUintArrayValue(bytes32 key, uint256 index) external view returns (uint256);
+    function getIntArrayValue(bytes32 key, uint256 index) external view returns (int256);
     function getAddressArrayValue(bytes32 key, uint256 index) external view returns (address);
     function getBoolArrayValue(bytes32 key, uint256 index) external view returns (bool);
     function getBytesArrayValue(bytes32 key, uint256 index) external view returns (bytes32);
 
     //Array Deleters
     function deleteUint(bytes32 key, uint256 index) external;
+    function deleteInt(bytes32 key, uint256 index) external;
     function deleteAddress(bytes32 key, uint256 index) external;
     function deleteBool(bytes32 key, uint256 index) external;
     function deleteBytes(bytes32 key, uint256 index) external;
 
     //Array Length
     function lengthUint(bytes32 key) external view returns (uint256);
+    function lengthInt(bytes32 key) external view returns (uint256);
     function lengthAddress(bytes32 key) external view returns (uint256);
     function lengthBool(bytes32 key) external view returns (uint256);
     function lengthBytes(bytes32 key) external view returns (uint256);

--- a/contracts/interfaces/IEternalTreasury.sol
+++ b/contracts/interfaces/IEternalTreasury.sol
@@ -13,22 +13,24 @@ interface IEternalTreasury {
     function settleGage(address receiver, uint256 id, bool winner) external;
     // Stake a given amount of ETRNL
     function stake(uint256 amount) external;
-    // Unstake a given amount of ETRNL and withdraw any associated rewards in terms of the desired reserve asset
-    function unstake(uint256 amount, address asset) external;
+    // Unstake a given amount of ETRNL and withdraw staking rewards proportional to the amount (in ETRNL)
+    function unstake(uint256 amount) external;
     // View the ETRNL/AVAX pair address
     function viewPair() external view returns(address);
     // View whether a liquidity swap is in progress
     function viewUndergoingSwap() external view returns(bool);
     // Provides liquidity for the ETRNL/AVAX pair for the ETRNL token contract
     function provideLiquidity(uint256 contractBalance) external;
+    // Computes the minimum amount of two assets needed to provide liquidity given one asset amount
+    function computeMinAmounts(address asset, address otherAsset, uint256 amountAsset, uint256 uncertainty) external view returns(uint256 minOtherAsset, uint256 minAsset, uint256 amountOtherAsset);
+    // Converts a given staked amount into the reserve number space
+    function convertToReserve(uint256 amount) external view returns(uint256);
+    // Converts a given reserve amount into the regular number space (staked)
+    function convertToStaked(uint256 reserveAmount) external view returns(uint256);
     // Allows the withdrawal of AVAX in the contract
     function withdrawAVAX(address payable recipient, uint256 amount) external;
     // Allows the withdrawal of an asset present in the contract
     function withdrawAsset(address asset, address recipient, uint256 amount) external;
-    // Sets the address of the Eternal Factory contract
-    function setEternalFactory(address newContract) external;
-    // Sets the address of the Eternal Token contract
-    function setEternalToken(address newContract) external;
 
     // Signals a disabling/enabling of the automatic liquidity provision
     event AutomaticLiquidityProvisionUpdated(bool value);
@@ -39,7 +41,7 @@ interface IEternalTreasury {
     // Signals that some of an asset balance has been sent to a given address by decision of the DAO
     event AssetTransferred(address asset, uint256 amount, address recipient);
     // Signals that a user staked a given amount of ETRNL 
-    event Stake(address user, uint256 amount);
+    event Stake(address indexed user, uint256 amount);
     // Signals that a user unstaked a given amount of ETRNL
-    event Unstake(address user, uint256 amount);
+    event Unstake(address indexed user, uint256 amount);
 }

--- a/contracts/main/EternalOffering.sol
+++ b/contracts/main/EternalOffering.sol
@@ -167,7 +167,9 @@ contract EternalOffering {
         uint256 liquidity;
         // Compute the minimum amounts needed to provide liquidity and the equivalent of the asset in ETRNL
         (uint256 minETRNL, uint256 minAsset, uint256 amountETRNL) = computeMinAmounts(asset, address(eternal), amount, 200);
-        require(amountETRNL + liquidityOffered[msg.sender] <= (10 ** 7) * (10 ** 18), "Amount exceeds the user limit");
+        // Calculate risk
+        uint256 rRisk = totalETRNLOffered < LIMIT / 4 ? 3100 : (totalETRNLOffered < LIMIT / 2 ? 2600 : (totalETRNLOffered < LIMIT * 3 / 4 ? 2100 : 1600));
+        require(amountETRNL + (amountETRNL * (rRisk - 100) / (10 ** 4)) + liquidityOffered[msg.sender] <= (10 ** 7) * (10 ** 18), "Amount exceeds the user limit");
 
         // Compute the percent change condition
         uint256 percent = 500 * BASELINE * (10 ** 18) * TIME_CONSTANT * TIME_FACTOR / eternal.totalSupply();
@@ -187,9 +189,6 @@ contract EternalOffering {
         } else {
             asset = joeRouter.WAVAX();
         }
-
-        // Calculate risk and join the gage for the user and the Eternal Offering contract
-        uint256 rRisk = totalETRNLOffered < LIMIT / 4 ? 3100 : (totalETRNLOffered < LIMIT / 2 ? 2600 : (totalETRNLOffered < LIMIT * 3 / 4 ? 2100 : 1600));
 
         // Add liquidity to the ETRNL/Asset pair
         require(eternal.approve(address(joeRouter), amountETRNL), "Approve failed");

--- a/contracts/main/EternalOffering.sol
+++ b/contracts/main/EternalOffering.sol
@@ -26,9 +26,11 @@ contract EternalOffering {
     IJoeFactory public immutable joeFactory;
     // The Eternal token interface
     IERC20 public immutable eternal;
+    // The Eternal storage interface
+    IEternalStorage public immutable eternalStorage;
+    // The Eternal treasury interface
+    IEternalTreasury public immutable eternalTreasury;
 
-    // The address of the Eternal Treasury
-    address public immutable treasury;
     // The address of the ETRNL-MIM pair
     address public immutable mimPair;
     // The address of the ETRNL-AVAX pair
@@ -60,6 +62,8 @@ contract EternalOffering {
 
     // Keeps track of the latest Gage ID
     uint256 private lastId;
+    // The total amount of ETRNL needed for current active gages
+    uint256 private totalETRNLForGages;
     // The total number of ETRNL dispensed in this offering thus far
     uint256 private totalETRNLOffered;
     // The total number of MIM-ETRNL lp tokens acquired
@@ -71,8 +75,9 @@ contract EternalOffering {
 
 /////–––««« Constructor »»»––––\\\\\
 
-    constructor (address _eternal, address _treasury) {
+    constructor (address _eternal, address _treasury, address _storage) {
         // Set the initial Eternal token and storage interfaces
+        eternalStorage = IEternalStorage(_storage);
         eternal = IERC20(_eternal);
         IJoeRouter02 _joeRouter = IJoeRouter02(0x60aE616a2155Ee3d9A68541Ba4544862310933d4);
         IJoeFactory _joeFactory = IJoeFactory(_joeRouter.factory());
@@ -82,7 +87,7 @@ contract EternalOffering {
         // Create the pairs
         avaxPair = _joeFactory.getPair(_eternal, _joeRouter.WAVAX());
         mimPair = _joeFactory.createPair(_eternal, MIM);
-        treasury = _treasury;
+        eternalTreasury = IEternalTreasury(_treasury);
         offeringEnds = block.timestamp + 1 days;
     }
 
@@ -204,7 +209,8 @@ contract EternalOffering {
 
         // Update the offering variables
         liquidityOffered[msg.sender] += providedETRNL + (providedETRNL * (rRisk - 100) / (10 ** 4));
-        totalETRNLOffered += providedETRNL + (providedETRNL * (rRisk - 100) / (10 ** 4));
+        totalETRNLOffered += providedETRNL + (2 * providedETRNL * (rRisk - 100) / (10 ** 4));
+        totalETRNLForGages += providedETRNL * (rRisk - 100) / (10 ** 4);
 
         // Initialize the loyalty gage and transfer the user's instant reward
         newGage.initialize(asset, address(eternal), amount, providedETRNL, rRisk, 1000);
@@ -238,6 +244,7 @@ contract EternalOffering {
             dAmount += dAmount * dRisk / (10 ** 4);
         } else {
             dAmount -= dAmount * rRisk / (10 ** 4);
+            totalETRNLForGages -= dAmount * rRisk / (10 ** 4);
         }
         require(eternal.transfer(receiver, dAmount), "Failed to transfer ETRNL");
     }
@@ -318,20 +325,29 @@ contract EternalOffering {
         uint256 avaxBal = address(this).balance;
         // Send the MIM and AVAX balance of this contract to the Eternal Treasury if there is any dust leftover
         if (mimBal > 0) {
-            require(IERC20(MIM).transfer(treasury, mimBal), "MIM Transfer failed");
+            require(IERC20(MIM).transfer(address(eternalTreasury), mimBal), "MIM Transfer failed");
         }
         if (avaxBal > 0) {
-            (bool success,) = treasury.call{value: avaxBal}("");
+            (bool success,) = address(eternalTreasury).call{value: avaxBal}("");
             require(success, "AVAX transfer failed");
         }
 
         // Send any leftover ETRNL from this offering to the Eternal Treasury
-        if (etrnlBal > 0) {
-            require(eternal.transfer(treasury, etrnlBal), "ETRNL transfer failed");
+        if (etrnlBal > totalETRNLForGages) {
+            bytes32 treasury = keccak256(abi.encodePacked(address(eternalTreasury)));
+            bytes32 reserveBalance = keccak256(abi.encodePacked("reserveBalances", address(eternalTreasury)));
+            bytes32 stakedBalance = keccak256(abi.encodePacked("stakedBalances", address(eternalTreasury)));
+            bytes32 reserveStakedBalances = keccak256(abi.encodePacked("reserveStakedBalances", address(eternalTreasury)));
+            bytes32 totalStakedBalances = keccak256(abi.encodePacked("totalStakedBalances", address(eternalTreasury)));
+            eternalStorage.setUint(treasury, reserveBalance, eternalStorage.getUint(treasury, reserveBalance) + eternalTreasury.convertToReserve(etrnlBal - totalETRNLForGages));
+            eternalStorage.setUint(treasury, stakedBalance, eternalStorage.getUint(treasury, stakedBalance) + etrnlBal - totalETRNLForGages);
+            eternalStorage.setUint(treasury, reserveStakedBalances, eternalStorage.getUint(treasury, reserveStakedBalances) + eternalTreasury.convertToReserve(etrnlBal - totalETRNLForGages));
+            eternalStorage.setUint(treasury, totalStakedBalances, eternalStorage.getUint(treasury, totalStakedBalances) + etrnlBal - totalETRNLForGages);
+            require(eternal.transfer(address(eternalTreasury), etrnlBal - totalETRNLForGages), "ETRNL transfer failed");
         }
 
         // Send the lp tokens earned from this offering to the Eternal Treasury
-        require(IERC20(avaxPair).transfer(treasury, totalLpAVAX), "Failed to transfer AVAX lp");
-        require(IERC20(mimPair).transfer(treasury, totalLpMIM), "Failed to transfer MIM lp");
+        require(IERC20(avaxPair).transfer(address(eternalTreasury), totalLpAVAX), "Failed to transfer AVAX lp");
+        require(IERC20(mimPair).transfer(address(eternalTreasury), totalLpMIM), "Failed to transfer MIM lp");
     }
 }

--- a/contracts/main/EternalStorage.sol
+++ b/contracts/main/EternalStorage.sol
@@ -15,12 +15,14 @@ contract EternalStorage is IEternalStorage, Context {
 
     // Scalars
     mapping (bytes32 => mapping (bytes32 => uint256)) private uints;
+    mapping (bytes32 => mapping (bytes32 => int256)) private ints;
     mapping (bytes32 => mapping (bytes32 => address)) private addresses;
     mapping (bytes32 => mapping (bytes32 => bool)) private bools;
     mapping (bytes32 => mapping (bytes32 => bytes32)) private bytes32s;
 
     // Multi-value variables
     mapping(bytes32 => uint256[]) private manyUints;
+    mapping(bytes32 => int256[]) private manyInts;
     mapping(bytes32 => address[]) private manyAddresses;
     mapping(bytes32 => bool[]) private manyBools;
     mapping(bytes32 => bytes32[]) private manyBytes;
@@ -73,6 +75,20 @@ function initialize(address _treasury, address _token, address _factory, address
     }
 
     /**
+     * @notice Sets an int256 value for a given contract and key
+     * @param entity The keccak256 hash of the contract's address
+     * @param key The specified mapping key
+     * @param value The specified int256 value
+     * 
+     * Requirements:
+     *
+     * - Only callable by the latest version of any Eternal contract
+     */
+    function setInt(bytes32 entity, bytes32 key, int256 value) external override onlyLatestVersion {
+        ints[entity][key] = value;
+    }
+
+    /**
      * @notice Sets an address value for a given contract and key
      * @param entity The keccak256 hash of the contract's address
      * @param key The specified mapping key
@@ -115,7 +131,7 @@ function initialize(address _treasury, address _token, address _factory, address
     }    
 
     /**
-     * @notice Sets or pushes a uin256 array's element's value for a given key and index
+     * @notice Sets or pushes a uint256 array's element's value for a given key and index
      * @param key The specified mapping key
      * @param index The specified index of the array's element being modified
      * @param value The specified uint256 value
@@ -129,6 +145,24 @@ function initialize(address _treasury, address _token, address _factory, address
             manyUints[key].push(value);
         } else {
             manyUints[key][index] = value;
+        }
+    }
+
+    /**
+     * @notice Sets or pushes an int256 array's element's value for a given key and index
+     * @param key The specified mapping key
+     * @param index The specified index of the array's element being modified
+     * @param value The specified int256 value
+     * 
+     * Requirements:
+     *
+     * - Only callable by the latest version of any Eternal contract
+     */
+    function setIntArrayValue(bytes32 key, uint256 index, int256 value) external override onlyLatestVersion {
+        if (index == 0) {
+            manyInts[key].push(value);
+        } else {
+            manyInts[key][index] = value;
         }
     }
 
@@ -198,6 +232,16 @@ function initialize(address _treasury, address _token, address _factory, address
     }
 
     /**
+     * @notice Returns an int256 value for a given contract and key
+     * @param entity The keccak256 hash of the specified contract
+     * @param key The specified mapping key
+     * @return The int256 value mapped to the key
+     */
+    function getInt(bytes32 entity, bytes32 key) external view override returns (int256) {
+        return ints[entity][key];
+    }
+
+    /**
      * @notice Returns an address value for a given contract and key
      * @param entity The keccak256 hash of the specified contract
      * @param key The specified mapping key
@@ -235,6 +279,16 @@ function initialize(address _treasury, address _token, address _factory, address
      */
     function getUintArrayValue(bytes32 key, uint256 index) external view override returns (uint256) {
         return manyUints[key][index];
+    }
+
+    /**
+     * @notice Returns an int256 array's element's value for a given key and index
+     * @param key The specified mapping key
+     * @param index The specified index of the desired element
+     * @return The int256 value at the specified index for the specified array
+     */
+    function getIntArrayValue(bytes32 key, uint256 index) external view override returns (int256) {
+        return manyInts[key][index];
     }
 
     /**
@@ -282,6 +336,21 @@ function initialize(address _treasury, address _token, address _factory, address
         uint256 length = manyUints[key].length;
         manyUints[key][index] = manyUints[key][length - 1];
         manyUints[key].pop();
+    }
+
+    /** 
+     * @notice Deletes an int256 array's element for a given key and index
+     * @param key The specified mapping key
+     * @param index The specified index of the desired element
+     * 
+     * Requirements:
+     *
+     * - Only callable by the latest version of any Eternal contract
+     */
+    function deleteInt(bytes32 key, uint256 index) external override onlyLatestVersion {
+        uint256 length = manyInts[key].length;
+        manyInts[key][index] = manyInts[key][length - 1];
+        manyInts[key].pop();
     }
 
     /** 
@@ -338,6 +407,15 @@ function initialize(address _treasury, address _token, address _factory, address
      */
     function lengthUint(bytes32 key) external view override returns (uint256) {
         return manyUints[key].length;
+    }
+
+    /**
+     * @notice Returns the length of an int256 array for a given key
+     * @param key The specified mapping key
+     * @return The length of the array mapped to the key
+     */
+    function lengthInt(bytes32 key) external view override returns (uint256) {
+        return manyInts[key].length;
     }
 
     /**

--- a/contracts/main/EternalToken.sol
+++ b/contracts/main/EternalToken.sol
@@ -110,8 +110,9 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
         uint256 rSupply = (max - (max % ((10 ** 10) * (10 ** 18))));
         eternalStorage.setUint(entity, totalReflectedSupply, rSupply);
         eternalStorage.setUint(entity, tokenLiquidityThreshold, (10 ** 10) * (10 ** 18) / 1000);
-        // Distribute supply (10% and 5% to send to FundLock contracts, 42.5% to Treasury and 42.5% to the IGO contract)
-        eternalStorage.setUint(entity, keccak256(abi.encodePacked("reflectedBalances", _seedLock)), (rSupply / 100) * 10 );
+        // Distribute supply (10% to send to FundLock contracts for vesting, 5% to send for pre-seed investors, 42.5% to Treasury and 42.5% to the IGO contract)
+        eternalStorage.setUint(entity, keccak256(abi.encodePacked("reflectedBalances", _msgSender())), (rSupply / 100) * 5);
+        eternalStorage.setUint(entity, keccak256(abi.encodePacked("reflectedBalances", _seedLock)), (rSupply / 100) * 5);
         eternalStorage.setUint(entity, keccak256(abi.encodePacked("reflectedBalances", _privLock)), (rSupply / 100) * 5);
         eternalStorage.setUint(entity, keccak256(abi.encodePacked("reflectedBalances", _offering)), (rSupply / 1000) * 425);
         eternalStorage.setUint(entity, keccak256(abi.encodePacked("reflectedBalances", _eternalTreasury)), (rSupply / 1000) * 425);

--- a/contracts/main/EternalToken.sol
+++ b/contracts/main/EternalToken.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "../interfaces/IEternalFund.sol";
 import "../interfaces/IEternalTreasury.sol";
+import "../interfaces/IEternalFactory.sol";
 import "../interfaces/IEternalStorage.sol";
 import "../inheritances/OwnableEnhanced.sol";
 
@@ -22,6 +23,8 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
     IEternalStorage public immutable eternalStorage;
     // The Eternal treasury interface
     IEternalTreasury private eternalTreasury;
+    // The Eternal factory interface
+    IEternalFactory private eternalFactory;
 
     // The keccak256 hash of this contract's address
     bytes32 public immutable entity;
@@ -66,15 +69,6 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
     // The percentage of the fee taken at each transaction, that is used to auto-lock liquidity (x 10 ** 5)
     bytes32 public immutable liquidityProvisionRate;
 
-/////–––««« Variables: Transaction Tracking »»»––––\\\\\
-
-    // The total number of times ETRNL has been transacted with fees in the last full 24h period
-    bytes32 public immutable alpha;
-    // The total number of times ETRNL has been transacted with fees in the current 24h period (ongoing)
-    bytes32 public immutable transactionCount;
-    // Keeps track of the UNIX time to recalculate the average transaction estimate
-    bytes32 public immutable oneDayFromNow;
-
 /////–––««« Constructors & Initializers »»»––––\\\\\
 
     constructor (address _eternalStorage) {
@@ -90,9 +84,6 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
         burnRate = keccak256(abi.encodePacked("burnRate"));
         redistributionRate = keccak256(abi.encodePacked("redistributionRate"));
         liquidityProvisionRate = keccak256(abi.encodePacked("liquidityProvisionRate"));
-        alpha = keccak256(abi.encodePacked("alpha"));
-        transactionCount = keccak256(abi.encodePacked("transactionCount"));
-        oneDayFromNow = keccak256(abi.encodePacked("oneDayFromNow"));
         excludedAddresses = keccak256(abi.encodePacked("excludedAddresses"));
     } 
 
@@ -100,8 +91,9 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
      * @notice Initialize supplies and routers and create a pair. Mints total supply to the contract deployer. 
      * Exclude some addresses from fees and/or rewards. Sets initial rate values.
      */
-    function initialize(address _eternalTreasury, address _fund, address _offering, address _seedLock, address _privLock) external onlyAdmin {
+    function initialize(address _eternalTreasury, address _factory, address _fund, address _offering, address _seedLock, address _privLock) external onlyAdmin {
         eternalTreasury = IEternalTreasury(_eternalTreasury);
+        eternalFactory = IEternalFactory(_factory);
         // The largest possible number in a 256-bit integer
         uint256 max = ~uint256(0);
 
@@ -138,9 +130,6 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
         eternalStorage.setUint(entity, burnRate, 500);
         eternalStorage.setUint(entity, redistributionRate, 2500);
         eternalStorage.setUint(entity, liquidityProvisionRate, 1500);
-
-        // Initialize the transaction count time tracker
-        eternalStorage.setUint(entity, oneDayFromNow, block.timestamp + 1 days);
 
         // Designate the Eternal Fund
         attributeFundRights(_fund);
@@ -330,39 +319,38 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
         }
         emit Transfer(sender, recipient, netTransferAmount);
 
-        // Update the 24h transaction count if the current 24h period has not elapsed
-        {
-        uint256 currentCount = eternalStorage.getUint(entity, transactionCount);
-        uint256 aDayFromNow = eternalStorage.getUint(entity, oneDayFromNow);
-        if (takeFee && block.timestamp < aDayFromNow) {
-            eternalStorage.setUint(entity, transactionCount, currentCount + 1);
-        } else if (takeFee && block.timestamp >= aDayFromNow) {
-            // Else update alpha, and reset the transaction count and 24h period tracker
-            eternalStorage.setUint(entity, alpha, currentCount);
-            eternalStorage.setUint(entity, transactionCount, amount);
-            eternalStorage.setUint(entity, oneDayFromNow, block.timestamp + 1 days);
-        }
-        }
 
-        // Adjust the total reflected supply for the new fees
+        // Adjust the total reflected supply for the new fees and update the 24h transaction count
         // If the sender or recipient are excluded from fees, we ignore the fee altogether
         if (takeFee) {
-            // Perform a burn based on the burn rate 
-            uint256 deflationRate = eternalStorage.getUint(entity, burnRate);
-            _burn(address(this), amount * deflationRate / 100000, reflectedAmount * deflationRate / 100000);
-            // Redistribute based on the redistribution rate 
-            uint256 reflectedSupply = eternalStorage.getUint(entity, totalReflectedSupply);
-            uint256 rewardRate = eternalStorage.getUint(entity, redistributionRate);
-            eternalStorage.setUint(entity, totalReflectedSupply, reflectedSupply - (reflectedAmount * rewardRate / 100000));
-            // Store ETRNL away in the treasury based on the funding rate
-            bytes32 treasuryBalance = keccak256(abi.encodePacked("reflectedBalances", address(eternalTreasury)));
-            uint256 fundBalance = eternalStorage.getUint(entity, treasuryBalance);
-            uint256 fundRate = eternalStorage.getUint(entity, fundingRate);
-            eternalStorage.setUint(entity, treasuryBalance, fundBalance + (reflectedAmount * fundRate / 100000));
-            // Provide liquidity to the ETRNL/AVAX pair on TraderJoe based on the liquidity provision rate
-            uint256 liquidityRate = eternalStorage.getUint(entity, liquidityProvisionRate);
-            storeLiquidityFunds(sender, amount * liquidityRate / 100000, reflectedAmount * liquidityRate / 100000);
+            _takeFees(amount, reflectedAmount, sender);
         }
+    }
+
+    /**
+     * @notice Apply the effects of all four token fees on a given transaction and update the 24h transaction count
+     * @param amount The amount of ETRNL of the specified transaction
+     * @param reflectedAmount The reflected amount of ETRNL of the specified transaction
+     * @param sender The address of the sender of the specified transaction
+     */
+    function _takeFees(uint256 amount, uint256 reflectedAmount, address sender) private {
+        // Update the 24h transaction count
+        eternalFactory.updateCounters(amount);
+        // Perform a burn based on the burn rate 
+        uint256 deflationRate = eternalStorage.getUint(entity, burnRate);
+        _burn(address(this), amount * deflationRate / 100000, reflectedAmount * deflationRate / 100000);
+        // Redistribute based on the redistribution rate 
+        uint256 reflectedSupply = eternalStorage.getUint(entity, totalReflectedSupply);
+        uint256 rewardRate = eternalStorage.getUint(entity, redistributionRate);
+        eternalStorage.setUint(entity, totalReflectedSupply, reflectedSupply - (reflectedAmount * rewardRate / 100000));
+        // Store ETRNL away in the treasury based on the funding rate
+        bytes32 treasuryBalance = keccak256(abi.encodePacked("reflectedBalances", address(eternalTreasury)));
+        uint256 fundBalance = eternalStorage.getUint(entity, treasuryBalance);
+        uint256 fundRate = eternalStorage.getUint(entity, fundingRate);
+        eternalStorage.setUint(entity, treasuryBalance, fundBalance + (reflectedAmount * fundRate / 100000));
+        // Provide liquidity to the ETRNL/AVAX pair on TraderJoe based on the liquidity provision rate
+        uint256 liquidityRate = eternalStorage.getUint(entity, liquidityProvisionRate);
+        storeLiquidityFunds(sender, amount * liquidityRate / 100000, reflectedAmount * liquidityRate / 100000);
     }
     
     /**
@@ -541,5 +529,13 @@ contract EternalToken is IERC20, IERC20Metadata, OwnableEnhanced {
      */
     function setEternalTreasury(address newContract) external onlyFund {
         eternalTreasury = IEternalTreasury(newContract);
+    }
+
+    /**
+     * @notice Updates the address of the Eternal Factory contract
+     * @param newContract The new address for the Eternal Factory contract
+     */
+    function setEternalFactory (address newContract) external onlyFund {
+        eternalFactory = IEternalFactory(newContract);
     }
 }

--- a/contracts/main/EternalTreasury.sol
+++ b/contracts/main/EternalTreasury.sol
@@ -273,7 +273,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
             require(eternal.transfer(receiver, amountETRNL * dRisk / (10 ** 4)), "Failed to transfer ETRNL reward");
             // Compute the net liquidity rewards left to distribute to stakers
             //solhint-disable-next-line reentrancy
-            eternalRewards -= eternalRewards * dRisk / (10 ** 4);
+            eternalRewards = eternalRewards == 0 ? 0 : eternalRewards - (eternalRewards * dRisk / (10 ** 4));
         } else {
             amountAsset -= amountAsset * rRisk / (10 ** 4);
             // Compute the net liquidity rewards + gage deposit left to distribute to staker
@@ -283,6 +283,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
         require(IERC20(rAsset).transfer(receiver, amountAsset - eternalFee), "Failed to transfer ERC20 reward");
 
         // Update staker's fees w.r.t the gage fee, gage rewards and liquidity rewards
+        // Fees and rewards are both calculated in terms of ETRNL
         {
         uint256 totalFee = eternalRewards + (dAmount * eternalStorage.getUint(entity, feeRate) / (10 ** 5));
         eternalStorage.setUint(entity, reserveStakedBalances, eternalStorage.getUint(entity, reserveStakedBalances) - convertToReserve(totalFee));

--- a/contracts/main/EternalTreasury.sol
+++ b/contracts/main/EternalTreasury.sol
@@ -23,7 +23,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
     // The Trader Joe router interface
     IJoeRouter02 public immutable joeRouter;
     // The Trader Joe factory interface
-    IJoeFactory private immutable joeFactory;
+    IJoeFactory public immutable joeFactory;
     // The Eternal shared storage interface
     IEternalStorage public immutable eternalStorage;
     // The Eternal factory interface
@@ -35,7 +35,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
     // The keccak256 hash of this contract's address
     bytes32 public immutable entity;
 
-/////–––««« Variable: Hidden Mappings »»»––––\\\\\
+/////–––««« Variables: Hidden Mappings »»»––––\\\\\
 /**
     // The amount of ETRNL staked by any given individual user, converted to the "reserve" number space for fee distribution
     mapping (address => uint256) reserveBalances
@@ -105,7 +105,9 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
         // Set initial staking balances
         uint256 totalStake = eternal.balanceOf(address(this));
         eternalStorage.setUint(entity, totalStakedBalances, totalStake);
-        eternalStorage.setUint(entity, reserveStakedBalances, (max - (max % totalStake)));
+        eternalStorage.setUint(entity, reserveStakedBalances, (max - 100 * (max % totalStake)));
+        eternalStorage.setUint(entity, keccak256(abi.encodePacked("stakedBalances", address(this))), totalStake);
+        eternalStorage.setUint(entity, keccak256(abi.encodePacked("reserveBalances", address(this))), max - 10 * (max % totalStake));
         eternalStorage.setBool(entity, autoLiquidityProvision, true);
         
         // Set initial feeRate
@@ -156,7 +158,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
      * @param amount The specified staked amount
      * @return The reserve number space of the staked amount
      */
-    function convertToReserve(uint256 amount) private view returns(uint256) {
+    function convertToReserve(uint256 amount) public view override returns(uint256) {
         uint256 currentRate = eternalStorage.getUint(entity, reserveStakedBalances) / eternalStorage.getUint(entity, totalStakedBalances);
         return amount * currentRate;
     }
@@ -166,7 +168,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
      * @param reserveAmount The specified reserve amount
      * @return The regular number space value of the reserve amount
      */
-    function convertToStaked(uint256 reserveAmount) private view returns(uint256) {
+    function convertToStaked(uint256 reserveAmount) public view override returns(uint256) {
         uint256 currentRate = eternalStorage.getUint(entity, reserveStakedBalances) / eternalStorage.getUint(entity, totalStakedBalances);
         return reserveAmount / currentRate;
     }
@@ -181,10 +183,9 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
      * @return minAsset The minimum amount of Asset needed to provide liquidity (not given if uncertainty = 0)
      * @return amountOtherAsset The equivalent in otherAsset of the given amount of asset
      */
-    function computeMinAmounts(address asset, address otherAsset, uint256 amountAsset, uint256 uncertainty) private view returns(uint256 minOtherAsset, uint256 minAsset, uint256 amountOtherAsset) {
+    function computeMinAmounts(address asset, address otherAsset, uint256 amountAsset, uint256 uncertainty) public view override returns(uint256 minOtherAsset, uint256 minAsset, uint256 amountOtherAsset) {
         // Get the reserve ratios for the Asset-otherAsset pair
-        (uint256 reserveA, uint256 reserveB,) = IJoePair(joeFactory.getPair(asset, otherAsset)).getReserves();
-        (uint256 reserveAsset, uint256 reserveOtherAsset) = asset < otherAsset ? (reserveA, reserveB) : (reserveB, reserveA);
+        (uint256 reserveAsset, uint256 reserveOtherAsset) = fetchPairReserves(asset, otherAsset);
         // Determine a reasonable minimum amount of asset and otherAsset based on current reserves (with a tolerance =  1 / uncertainty)
         amountOtherAsset = joeRouter.quote(amountAsset, reserveAsset, reserveOtherAsset);
         if (uncertainty != 0) {
@@ -193,11 +194,54 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
             minOtherAsset = amountOtherAsset - (amountOtherAsset / uncertainty);
         }
     }
+    
+    /**
+     * @notice View the liquidity reserves of a given asset pair on Trader Joe
+     * @param asset The first asset of the specified pair
+     * @param otherAsset The second asset of the specified pair
+     * @return reserveAsset The reserve amount of the first asset
+     * @return reserveOtherAsset The reserve amount of the second asset
+     */
+    function fetchPairReserves(address asset, address otherAsset) private view returns(uint256 reserveAsset, uint256 reserveOtherAsset) {
+        (uint256 reserveA, uint256 reserveB,) = IJoePair(joeFactory.getPair(asset, otherAsset)).getReserves();
+        (reserveAsset, reserveOtherAsset) = asset < otherAsset ? (reserveA, reserveB) : (reserveB, reserveA);
+    }
 
+    /**
+     * @notice Removes liquidity provided by a liquid gage, for a given ETRNL-Asset pair
+     * @param rAsset The address of the specified asset
+     * @param providedAsset The amount of the asset which was provided as liquidity
+     * @param receiver The address of the liquid gage's receiver
+     * @return The amount of ETRNL and Asset obtained from removing liquidity
+     */
     function removeLiquidity(address rAsset, uint256 providedAsset, address receiver) private returns(uint256, uint256) {
         (uint256 minETRNL, uint256 minAsset,) = computeMinAmounts(rAsset, address(eternal), providedAsset, 200);
         uint256 liquidity = eternalStorage.getUint(entity, keccak256(abi.encodePacked("liquidity", receiver, rAsset)));
-        return joeRouter.removeLiquidity(address(eternal), rAsset, liquidity, minETRNL, minAsset, address(this), block.timestamp);
+        return joeRouter.removeLiquidity(address(eternal), rAsset, liquidity, minETRNL/2, minAsset/2, address(this), block.timestamp);
+    }
+
+    /**
+     * @notice Swap a given amount of tokens for ETRNL
+     * @param amount The specified amount of tokens
+     * @param asset The address of the asset being swapped
+     * @return minAsset The minimum amount of tokens received from the swap with a 1% uncertainty
+     */
+    function swapTokensForETRNL(uint256 amount, address asset) private returns(uint256 minAsset) {
+        address[] memory path = new address[](2);
+        path[0] = asset;
+        path[1] = address(eternal);
+
+        // Calculate the minimum amount of ETRNL to swap the asset for (with a tolerance of 1%)
+        (uint256 reserveETRNL, uint256 reserveAsset) = fetchPairReserves(address(eternal), asset);
+        minAsset = computeMinSwapAmount(amount, reserveAsset, reserveETRNL, 100);
+
+        // Swap the asset for ETRNL
+        require(IERC20(asset).approve(address(joeRouter), amount), "Approve failed");
+        if (asset == joeRouter.WAVAX()) {
+            joeRouter.swapExactAVAXForTokensSupportingFeeOnTransferTokens{value : amount}(minAsset, path, address(this), block.timestamp);
+        } else {
+            joeRouter.swapExactTokensForTokens(amount, minAsset, path, address(this), block.timestamp);
+        }
     }
 
 /////–––««« Gage-logic functions »»»––––\\\\\
@@ -223,7 +267,7 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
         uint256 providedETRNL;
         uint256 providedAsset;
         uint256 liquidity;
-        (uint256 minETRNL, uint256 minAsset, uint256 amountETRNL) = computeMinAmounts(asset, address(eternal), userAmount, 200);
+        (uint256 minETRNL, uint256 minAsset, uint256 amountETRNL) = computeMinAmounts(asset, address(eternal), userAmount, 100);
         
         // Add liquidity to the ETRNL/Asset pair
         require(eternal.approve(address(joeRouter), amountETRNL), "Approve failed");
@@ -236,6 +280,9 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
         // Save the true amount provided as liquidity by the receiver and the actual liquidity amount
         eternalStorage.setUint(entity, keccak256(abi.encodePacked("amountProvided", receiver, asset)), providedAsset);
         eternalStorage.setUint(entity, keccak256(abi.encodePacked("liquidity", receiver, asset)), liquidity);
+
+        // Update the 24h count of ETRNL flowing out of the treasury
+        eternalFactory.updateCounters(providedAsset + (2 * providedAsset * dRisk / (10 ** 4)));
         
         // Initialize the liquid gage and transfer the user's instant reward
         ILoyaltyGage(gage).initialize(asset, address(eternal), userAmount, providedETRNL, rRisk, dRisk);
@@ -282,10 +329,10 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
         }
         require(IERC20(rAsset).transfer(receiver, amountAsset - eternalFee), "Failed to transfer ERC20 reward");
 
-        // Update staker's fees w.r.t the gage fee, gage rewards and liquidity rewards
+        // Update staker's fees w.r.t the gage fee, gage rewards and liquidity rewards and buy ETRNL with the fee
         // Fees and rewards are both calculated in terms of ETRNL
         {
-        uint256 totalFee = eternalRewards + (dAmount * eternalStorage.getUint(entity, feeRate) / (10 ** 5));
+        uint256 totalFee = eternalRewards + swapTokensForETRNL(eternalFee, rAsset);
         eternalStorage.setUint(entity, reserveStakedBalances, eternalStorage.getUint(entity, reserveStakedBalances) - convertToReserve(totalFee));
         }
     }
@@ -319,55 +366,57 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
     }
 
     /**
-     * @notice Unstakes a user's given amount of ETRNL and transfers the user's accumulated rewards in terms of a given asset
+     * @notice Unstakes a user's given amount of ETRNL and transfers the user's accumulated rewards proportional to that amount (in ETRNL)
      * @param amount The specified amount of ETRNL being unstaked
-     * @param asset The specified asset which the rewards are transferred in
      * 
      * Requirements:
      *
      * - A liquidity swap should not be in progress
-     * - User staked balance must have enough tokens to support the withdrawal 
      */
-    function unstake(uint256 amount, address asset) external override activityHalted {
+    function unstake(uint256 amount) external override {
         bytes32 stakedBalances = keccak256(abi.encodePacked("stakedBalances", _msgSender()));
         uint256 stakedBalance = eternalStorage.getUint(entity, stakedBalances);
         require(amount <= stakedBalance , "Amount exceeds staked balance");
-        require(IERC20(asset).balanceOf(address(this)) > 0, "Asset not in reserves");
-
+     
         emit Unstake(_msgSender(), amount);
-        // Update user/total staked and reserve balances
         bytes32 reserveBalances = keccak256(abi.encodePacked("reserveBalances", _msgSender()));
         uint256 reserveBalance = eternalStorage.getUint(entity, reserveBalances);
         // Reward user with percentage of fees proportional to the amount he is withdrawing
         uint256 reserveAmount = amount * reserveBalance / stakedBalance;
+        // Update user/total staked and reserve balances
         eternalStorage.setUint(entity, reserveBalances, reserveBalance - reserveAmount);
         eternalStorage.setUint(entity, stakedBalances, stakedBalance - amount);
         eternalStorage.setUint(entity, reserveStakedBalances, eternalStorage.getUint(entity, reserveStakedBalances) - reserveAmount);
         eternalStorage.setUint(entity, totalStakedBalances, eternalStorage.getUint(entity, totalStakedBalances) - amount);
 
-        if (asset != address(eternal)) {
-            (,,uint256 amountAsset) = computeMinAmounts(address(eternal), asset, convertToStaked(reserveAmount) - amount, 0);
-            require(IERC20(asset).transfer(_msgSender(), amountAsset), "Transfer failed");
-            require(eternal.transfer(_msgSender(), amount), "Transfer failed");
-        } else {
-            require(eternal.transfer(_msgSender(), convertToStaked(reserveAmount)), "Transfer failed");
-        }
+        require(eternal.transfer(_msgSender(), convertToStaked(reserveAmount)), "Transfer failed");
     }
 
 /////–––««« Automatic liquidity provision functions »»»––––\\\\\
 
     /**
+     * @notice Computes the minimum amount to swap a given asset for another asset, with a given percentage uncertainty
+     * @param amountAsset The specified asset being swapped
+     * @param reserveAsset The reserve of the asset being swapped
+     * @param reserveOtherAsset The reserve of the asset being swapped for
+     * @param uncertainty The denominator of the percentage uncertainty if it were viewed as (1  / uncertainty)
+     */
+    function computeMinSwapAmount(uint256 amountAsset, uint256 reserveAsset, uint256 reserveOtherAsset, uint256 uncertainty) private view returns(uint256 minOtherAsset) {
+        uint256 amountOtherAsset = joeRouter.getAmountOut(amountAsset, reserveAsset, reserveOtherAsset);
+        minOtherAsset = amountOtherAsset - (amountOtherAsset / uncertainty);
+    }
+
+    /**
      * @notice Swaps a given amount of ETRNL for AVAX using Trader Joe. (Used for auto-liquidity swaps)
      * @param amount The amount of ETRNL to be swapped for AVAX
      */
-    function swapTokensForAVAX(uint256 amount, uint256 reserveETRNL, uint256 reserveAVAX) private {
+    function swapETRNLForAVAX(uint256 amount, uint256 reserveETRNL, uint256 reserveAVAX) private {
         address[] memory path = new address[](2);
-        path[0] = address(this);
+        path[0] = address(eternal);
         path[1] = joeRouter.WAVAX();
 
         // Calculate the minimum amount of AVAX to swap the ETRNL for (with a tolerance of 1%)
-        uint256 minAVAX = joeRouter.getAmountOut(amount, reserveETRNL, reserveAVAX);
-        minAVAX -= minAVAX / 100;
+        uint256 minAVAX = computeMinSwapAmount(amount, reserveETRNL, reserveAVAX, 100);
 
         // Swap the ETRNL for AVAX
         require(eternal.approve(address(joeRouter), amount), "Approve failed");
@@ -401,12 +450,11 @@ import "@traderjoe-xyz/core/contracts/traderjoe/interfaces/IJoePair.sol";
         uint256 amountETRNL = contractBalance - half;
 
         // Get the reserve ratios for the ETRNL-AVAX pair
-        (uint256 reserveA, uint256 reserveB,) = IJoePair(joePair).getReserves();
-        (uint256 reserveETRNL, uint256 reserveAVAX) = address(eternal) < joeRouter.WAVAX() ? (reserveA, reserveB) : (reserveB, reserveA);
+        (uint256 reserveETRNL, uint256 reserveAVAX) = fetchPairReserves(address(eternal), joeRouter.WAVAX());
         // Capture the initial balance to later compute the difference
         uint256 initialBalance = address(this).balance;
         // Swap half the contract's ETRNL balance to AVAX
-        swapTokensForAVAX(half, reserveETRNL, reserveAVAX);
+        swapETRNLForAVAX(half, reserveETRNL, reserveAVAX);
         // Compute the amount of AVAX received from the swap
         uint256 amountAVAX = address(this).balance - initialBalance;
         


### PR DESCRIPTION
What – A gaging limit is added to the Eternal Factory. Alpha and Beta estimates are updated by a general function in the Eternal Factory. Handling of fees in the token contract is now its own function (_takeFee). Staking is now purely in the form of ETRNL. Any ETRNL leaks have been changed.
Why – The gaging limit is necessary to ensure that redistribution/funding rewards are kept at a minimum in the Eternal Treasury, which allows for sustainable operations. Alpha and Beta estimates have been moved to the factory to prevent the max contract size issue and to improve code readability. Separation of functions in _transfer allows better code readability. Staking needs to be purely in the form of ETRNL to prevent any issues with stakers drying up the treasury reserves. ETRNL leaks needed to be fixed to ensure that the variables tracking the amount of ETRNL held by the treasury and stakers is an accurate reflection of the actual amounts.
How – Gaging limit is obtained by computing the total amount of ETRNL+rewards held by the treasury minus that of the stakers. This calculation may change in future updates. Alpha and Beta estimates are now simply updated every time a transaction with fees occurs or a liquid gage is initialized, through the updateCounter() function. Eternal Factory also now holds all of the related variables to the aforementioned. Staking has been changed to only return ETRNL reserves, and not rewards in the form of other assets. ETRNL leaks have been fixed by allowing the treasury to buy ETRNL using the gaging fee, hence the reserveBalances is always accurately portraying how much ETRNL is available to stakers and the treasury.