### PR TITLE
Testing round #2 fixes

### DIFF
--- a/contracts/interfaces/IEternalTreasury.sol
+++ b/contracts/interfaces/IEternalTreasury.sol
@@ -10,7 +10,7 @@ interface IEternalTreasury {
     // Provides liquidity for a given liquid gage and transfers instantaneous rewards to the receiver
     function fundEternalLiquidGage(address _gage, address user, address asset, uint256 amount, uint256 risk, uint256 bonus) external payable;
     // Used by gages to compute and distribute ETRNL liquid gage rewards appropriately
-    function settleGage(address receiver, uint256 id, bool winner) external;
+    function settleGage(address payable receiver, uint256 id, bool winner) external;
     // Stake a given amount of ETRNL
     function stake(uint256 amount) external;
     // Unstake a given amount of ETRNL and withdraw staking rewards proportional to the amount (in ETRNL)

--- a/contracts/main/EternalFactory.sol
+++ b/contracts/main/EternalFactory.sol
@@ -142,7 +142,7 @@ contract EternalFactory is IEternalFactory, OwnableEnhanced {
         eternalStorage.setUint(entity, lastId, idLast);
 
         // Deploy a new Gage
-        LoyaltyGage newGage = new LoyaltyGage(idLast, percent, 2, false, address(eternalTreasury), _msgSender(), address(this));
+        LoyaltyGage newGage = new LoyaltyGage(idLast, percent, 2, false, address(eternalTreasury), _msgSender(), address(eternalStorage));
         emit NewGage(idLast, address(newGage));
         eternalStorage.setAddress(entity, keccak256(abi.encodePacked("gages", idLast)), address(newGage));
 

--- a/contracts/main/EternalOffering.sol
+++ b/contracts/main/EternalOffering.sol
@@ -54,7 +54,7 @@ contract EternalOffering {
     // The minimum token value estimate of transactions in 24h, used in case the alpha value is not determined yet
     uint256 public constant BASELINE = 10 ** 7;
     // The number of ETRNL allocated
-    uint256 public constant LIMIT = 4207500 * (10 ** 3);
+    uint256 public constant LIMIT = 4207500 * (10 ** 21);
     // The MIM address
     address public constant MIM = 0x130966628846BFd36ff31a822705796e8cb8C18D;
 
@@ -183,7 +183,7 @@ contract EternalOffering {
         participated[msg.sender] = true;
 
         // Deploy a new Gage
-        LoyaltyGage newGage = new LoyaltyGage(lastId, percent, 2, false, address(this), msg.sender, address(this));
+        LoyaltyGage newGage = new LoyaltyGage(lastId, percent, 2, false, address(this), msg.sender, address(eternalStorage));
         emit NewGage(lastId, address(newGage));
         gages[lastId] = address(newGage);
 

--- a/contracts/main/EternalStorage.sol
+++ b/contracts/main/EternalStorage.sol
@@ -32,11 +32,12 @@ contract EternalStorage is IEternalStorage, Context {
 //solhint-disable-next-line no-empty-blocks
 constructor () {}
 
-function initialize(address _treasury, address _token, address _factory, address _fund) external {
+function initialize(address _treasury, address _token, address _factory, address _fund, address _offering) external {
     bytes32 treasury = keccak256(abi.encodePacked(_treasury));
     bytes32 token = keccak256(abi.encodePacked(_token));
     bytes32 factory = keccak256(abi.encodePacked(_factory));
     bytes32 fund = keccak256(abi.encodePacked(_fund));
+    bytes32 offering = keccak256(abi.encodePacked(_offering));
     bytes32 eternalStorage = keccak256(abi.encodePacked(address(this)));
 
     require(addresses[eternalStorage][token] == address(0), "Initial contracts already set");
@@ -44,6 +45,7 @@ function initialize(address _treasury, address _token, address _factory, address
     addresses[eternalStorage][token] = _token;
     addresses[eternalStorage][factory] = _factory;
     addresses[eternalStorage][fund] = _fund;
+    addresses[eternalStorage][offering] = _offering;
 }
 
 /////–––««« Modifiers »»»––––\\\\\


### PR DESCRIPTION
1. Implements a way to always obtain AVAX instead of WAVAX from the treasury
2. Fixes the wrong address input when creating a loyalty gage